### PR TITLE
Change return type of Object.create

### DIFF
--- a/packages/documentation/copy/en/handbook-v1/Basic Types.md
+++ b/packages/documentation/copy/en/handbook-v1/Basic Types.md
@@ -334,7 +334,7 @@ With `object` type, APIs like `Object.create` can be better represented. For exa
 
 ```ts twoslash
 // @errors: 2345
-declare function create(o: object | null): void;
+declare function create(o: object | null): object;
 
 // OK
 create({ prop: 0 });


### PR DESCRIPTION
I'm just reading this for the first time, but shouldn't Object.create return object?